### PR TITLE
[ADD] estate: Create base files and first model T#72976

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,83 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coveragerc
+.coverage.*
+et
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Vi swap file
+*.swp
+
+# Pycharm project files
+.idea
+
+# docker JSON packages
+package-lock.json
+package.json
+
+# docker node_modules
+node_modules/
+
+# pre-commit-vauxoo
+.editorconfig
+.eslintrc*
+.flake8*
+.isort.cfg
+.pre-commit*.yaml
+.prettierrc.yml
+.pylintrc*
+pyproject.toml
+.bandit

--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# oddo-gettingstarted
-Getting started project for Odoo developer

--- a/doc8.ini
+++ b/doc8.ini
@@ -1,0 +1,8 @@
+[doc8]
+
+file-encoding="UTF-8"
+# Ignore
+#   D001: Line too long
+ignore=D001
+allow-long-titles=True
+sphinx=True

--- a/estate/README.rst
+++ b/estate/README.rst
@@ -1,0 +1,5 @@
+## Real Estate
+
+Real Estate module for Odoo training project.
+[Reference link.](https://www.odoo.com/documentation/16.0/developer/tutorials/getting_started.html)
+

--- a/estate/__init__.py
+++ b/estate/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -1,0 +1,10 @@
+{
+    "name": "Estate",
+    "author": "Vauxoo",
+    "depends": [
+        "base",
+    ],
+    "installable": True,
+    "application": True,
+    "license": "LGPL-3",
+}

--- a/estate/models/__init__.py
+++ b/estate/models/__init__.py
@@ -1,0 +1,1 @@
+from . import estate_property

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -1,0 +1,27 @@
+from odoo import fields, models
+
+
+class EstateProperty(models.Model):
+    _name = "estate.property"
+    _description = "Estate property model"
+
+    name = fields.Char(required=True)
+    description = fields.Text()
+    postcode = fields.Char()
+    date_availability = fields.Date(help="Date from when it will be available.")
+    expected_price = fields.Float(required=True, help="Price at which you wish to sell the property.")
+    selling_price = fields.Float()
+    bedrooms = fields.Integer()
+    living_area = fields.Integer()
+    facades = fields.Integer()
+    garage = fields.Boolean()
+    garden = fields.Boolean()
+    garden_area = fields.Integer()
+    garden_orientation = fields.Selection(
+        selection=[
+            ("north", "North"),
+            ("south", "South"),
+            ("east", "East"),
+            ("west", "West"),
+        ]
+    )


### PR DESCRIPTION
- Create base files `__init__.py` and `__manifest__.py` for `estate` application. Link to the exercise: https://www.odoo.com/documentation/16.0/developer/tutorials/getting_started/03_newapp.html

- Creation of the first model `estate.property`, including its base fields. Link to the exercise: https://www.odoo.com/documentation/16.0/developer/tutorials/getting_started/04_basicmodel.html

