### PR TITLE
[ADD] estate: Add security and UI elements

### DIFF
--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -6,6 +6,8 @@
     ],
     "data": [
         "security/ir.model.access.csv",
+        "views/estate_property_views.xml",
+        "views/estate_menus.xml",
     ],
     "installable": True,
     "application": True,

--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -4,6 +4,9 @@
     "depends": [
         "base",
     ],
+    "data": [
+        "security/ir.model.access.csv",
+    ],
     "installable": True,
     "application": True,
     "license": "LGPL-3",

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -8,10 +8,12 @@ class EstateProperty(models.Model):
     name = fields.Char(required=True)
     description = fields.Text()
     postcode = fields.Char()
-    date_availability = fields.Date(help="Date from when it will be available.")
+    date_availability = fields.Date(
+        copy=False, default=fields.Date.add(fields.Date.today(), months=3), help="Date from when it will be available."
+    )
     expected_price = fields.Float(required=True, help="Price at which you wish to sell the property.")
-    selling_price = fields.Float()
-    bedrooms = fields.Integer()
+    selling_price = fields.Float(readonly=True, copy=False)
+    bedrooms = fields.Integer(default=2)
     living_area = fields.Integer()
     facades = fields.Integer()
     garage = fields.Boolean()

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -27,3 +27,16 @@ class EstateProperty(models.Model):
             ("west", "West"),
         ]
     )
+    active = fields.Boolean(default=True)
+    state = fields.Selection(
+        selection=[
+            ("new", "New"),
+            ("offer_received", "Offer Received"),
+            ("offer_accepted", "Offer Accepted"),
+            ("sold", "Sold"),
+            ("canceled", "Canceled"),
+        ],
+        required=True,
+        default="new",
+        copy=False,
+    )

--- a/estate/security/ir.model.access.csv
+++ b/estate/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_estate_property_model,access_estate_property_model,model_estate_property,base.group_user,1,1,1,1

--- a/estate/views/estate_menus.xml
+++ b/estate/views/estate_menus.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <menuitem id="estate_menu_root" name="Real Estate">
+        <menuitem id="advertisements_menu" name="Advertisements">
+            <menuitem id="estate_property_menu" name="Properties" action="estate_property_action" />
+        </menuitem>
+    </menuitem>
+</odoo>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="estate_property_action" model="ir.actions.act_window">
+        <field name="name">Estate Property</field>
+        <field name="res_model">estate.property</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+</odoo>


### PR DESCRIPTION
**Chapter 5**
- Security file for `estate.property` model is created to grant access to `base.group_user`. Reference link: 
https://www.odoo.com/documentation/16.0/developer/tutorials/getting_started/05_securityintro.html

**Chapter 6**
- Menus and its action are included, allowing to navigate to tree and form view of `estate.property` model.
- Some field attributes as `default` and `copy` are included in `estate.property` model to improve form view behaviour.
- Also add `active` and `state` fields to keep track of records. 
- Reference link: https://www.odoo.com/documentation/16.0/developer/tutorials/getting_started/06_firstui.html

