### PR TITLE
[ADD] estate: Add related and computed fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ node_modules/
 .pylintrc*
 pyproject.toml
 .bandit
+
+.vscode

--- a/estate/README.rst
+++ b/estate/README.rst
@@ -2,4 +2,3 @@
 
 Real Estate module for Odoo training project.
 [Reference link.](https://www.odoo.com/documentation/16.0/developer/tutorials/getting_started.html)
-

--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -9,6 +9,7 @@
         "views/estate_property_views.xml",
         "views/estate_property_type_views.xml",
         "views/estate_property_tag_views.xml",
+        "views/estate_property_offer_views.xml",
         "views/estate_menus.xml",
     ],
     "installable": True,

--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -8,6 +8,7 @@
         "security/ir.model.access.csv",
         "views/estate_property_views.xml",
         "views/estate_property_type_views.xml",
+        "views/estate_property_tag_views.xml",
         "views/estate_menus.xml",
     ],
     "installable": True,

--- a/estate/models/__init__.py
+++ b/estate/models/__init__.py
@@ -1,3 +1,4 @@
 from . import estate_property
 from . import estate_property_type
 from . import estate_property_tag
+from . import estate_property_offer

--- a/estate/models/__init__.py
+++ b/estate/models/__init__.py
@@ -1,2 +1,3 @@
 from . import estate_property
 from . import estate_property_type
+from . import estate_property_tag

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -44,3 +44,4 @@ class EstateProperty(models.Model):
     buyer_id = fields.Many2one("res.partner", copy=False)
     salesperson_id = fields.Many2one("res.users", string="Salesman", default=lambda self: self.env.user)
     tag_ids = fields.Many2many("estate.property.tag")
+    offer_ids = fields.One2many("estate.property.offer", "property_id")

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -43,3 +43,4 @@ class EstateProperty(models.Model):
     property_type_id = fields.Many2one("estate.property.type")
     buyer_id = fields.Many2one("res.partner", copy=False)
     salesperson_id = fields.Many2one("res.users", string="Salesman", default=lambda self: self.env.user)
+    tag_ids = fields.Many2many("estate.property.tag")

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class EstateProperty(models.Model):
@@ -45,3 +45,24 @@ class EstateProperty(models.Model):
     salesperson_id = fields.Many2one("res.users", string="Salesman", default=lambda self: self.env.user)
     tag_ids = fields.Many2many("estate.property.tag")
     offer_ids = fields.One2many("estate.property.offer", "property_id")
+    total_area = fields.Integer(compute="_compute_total_area")
+    best_price = fields.Float(compute="_compute_best_price")
+
+    @api.depends("living_area", "garden_area")
+    def _compute_total_area(self):
+        for record in self:
+            record.total_area = record.living_area + record.garden_area
+
+    @api.depends("offer_ids.price")
+    def _compute_best_price(self):
+        for record in self:
+            record.best_price = max(record.offer_ids.mapped("price")) if record.offer_ids else 0
+
+    @api.onchange("garden")
+    def _onchange_garden(self):
+        if self.garden:
+            self.garden_area = 10
+            self.garden_orientation = "north"
+        else:
+            self.garden_area = 0
+            self.garden_orientation = None

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -40,3 +40,6 @@ class EstateProperty(models.Model):
         default="new",
         copy=False,
     )
+    property_type_id = fields.Many2one("estate.property.type")
+    buyer_id = fields.Many2one("res.partner", copy=False)
+    salesperson_id = fields.Many2one("res.users", string="Salesman", default=lambda self: self.env.user)

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -1,0 +1,17 @@
+from odoo import fields, models
+
+
+class PropertyOffer(models.Model):
+    _name = "estate.property.offer"
+    _description = "Offers for properties"
+
+    price = fields.Float()
+    status = fields.Selection(
+        selection=[
+            ("accepted", "Accepted"),
+            ("refused", "Refused"),
+        ],
+        copy=False,
+    )
+    partner_id = fields.Many2one("res.partner", required=True)
+    property_id = fields.Many2one("estate.property", required=True)

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class PropertyOffer(models.Model):
@@ -15,3 +15,16 @@ class PropertyOffer(models.Model):
     )
     partner_id = fields.Many2one("res.partner", required=True)
     property_id = fields.Many2one("estate.property", required=True)
+    validity = fields.Integer(default=7, string="Validity (days)")
+    date_deadline = fields.Date(compute="_compute_date_deadline", inverse="_inverse_validity", string="Deadline")
+
+    def _inverse_validity(self):
+        for record in self:
+            end_date = fields.Date.to_date(record.create_date) if record.create_date else fields.Date.today()
+            record.validity = (record.date_deadline - end_date).days
+
+    @api.depends("validity")
+    def _compute_date_deadline(self):
+        for record in self:
+            start_date = record.create_date if record.create_date else fields.Date.today()
+            record.date_deadline = fields.Date.add(start_date, days=record.validity)

--- a/estate/models/estate_property_tag.py
+++ b/estate/models/estate_property_tag.py
@@ -1,0 +1,8 @@
+from odoo import fields, models
+
+
+class PropertyTag(models.Model):
+    _name = "estate.property.tag"
+    _description = "Tags for properties"
+
+    name = fields.Char(required=True)

--- a/estate/security/ir.model.access.csv
+++ b/estate/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_estate_property_model,access_estate_property_model,model_estate_property,base.group_user,1,1,1,1
 access_estate_property_type_model,access_estate_property_type_model,model_estate_property_type,base.group_user,1,1,1,1
+access_estate_property_tag_model,access_estate_property_tag_model,model_estate_property_tag,base.group_user,1,1,1,1

--- a/estate/security/ir.model.access.csv
+++ b/estate/security/ir.model.access.csv
@@ -2,3 +2,4 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_estate_property_model,access_estate_property_model,model_estate_property,base.group_user,1,1,1,1
 access_estate_property_type_model,access_estate_property_type_model,model_estate_property_type,base.group_user,1,1,1,1
 access_estate_property_tag_model,access_estate_property_tag_model,model_estate_property_tag,base.group_user,1,1,1,1
+access_estate_property_offer_model,access_estate_property_offer_model,model_estate_property_offer,base.group_user,1,1,1,1

--- a/estate/views/estate_menus.xml
+++ b/estate/views/estate_menus.xml
@@ -6,6 +6,7 @@
         </menuitem>
         <menuitem id="settings_menu" name="Settings">
             <menuitem id="estate_property_type_menu" name="Property Types" action="estate_property_type_action" />
+            <menuitem id="estate_property_tag_menu" name="Property Tags" action="estate_property_tag_action" />
         </menuitem>
     </menuitem>
 </odoo>

--- a/estate/views/estate_property_offer_views.xml
+++ b/estate/views/estate_property_offer_views.xml
@@ -7,6 +7,8 @@
             <tree>
                 <field name="price" />
                 <field name="partner_id" />
+                <field name="validity" />
+                <field name="date_deadline" />
                 <field name="status" />
             </tree>
         </field>
@@ -21,6 +23,8 @@
                     <group>
                         <field name="price" />
                         <field name="partner_id" />
+                        <field name="validity" />
+                        <field name="date_deadline" />
                         <field name="status" />
                     </group>
                 </sheet>

--- a/estate/views/estate_property_offer_views.xml
+++ b/estate/views/estate_property_offer_views.xml
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="estate_property_offer_view_tree" model="ir.ui.view">
+        <field name="name">estate.property.offer.tree</field>
+        <field name="model">estate.property.offer</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="price" />
+                <field name="partner_id" />
+                <field name="status" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="estate_property_offer_view_form" model="ir.ui.view">
+        <field name="name">estate.property.offer.form</field>
+        <field name="model">estate.property.offer</field>
+        <field name="arch" type="xml">
+            <form string="Offer">
+                <sheet>
+                    <group>
+                        <field name="price" />
+                        <field name="partner_id" />
+                        <field name="status" />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/estate/views/estate_property_tag_views.xml
+++ b/estate/views/estate_property_tag_views.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="estate_property_tag_action" model="ir.actions.act_window">
+        <field name="name">Property Tags</field>
+        <field name="res_model">estate.property.tag</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+</odoo>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -7,6 +7,7 @@
             <tree>
                 <field name="name" string="Title" />
                 <field name="property_type_id" />
+                <field name="tag_ids" widget="many2many_tags" />
                 <field name="postcode" />
                 <field name="bedrooms" />
                 <field name="living_area" string="Living Area (sqm)" />
@@ -24,8 +25,8 @@
             <form string="Property">
                 <sheet>
                     <group>
-                        <field name="name" style="font-size:24pt; margin-bottom: 16px;" />
-                        <newline />
+                        <field name="name" style="font-size:24pt;" />
+                        <field name="tag_ids" widget="many2many_tags" />
                         <group>
                             <field name="property_type_id" />
                             <field name="postcode" />

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -6,6 +6,7 @@
         <field name="arch" type="xml">
             <tree>
                 <field name="name" string="Title" />
+                <field name="property_type_id" />
                 <field name="postcode" />
                 <field name="bedrooms" />
                 <field name="living_area" string="Living Area (sqm)" />
@@ -23,9 +24,10 @@
             <form string="Property">
                 <sheet>
                     <group>
-                        <field name="name" style="font-size:25pt; margin-bottom: 16px;" />
+                        <field name="name" style="font-size:24pt; margin-bottom: 16px;" />
                         <newline />
                         <group>
+                            <field name="property_type_id" />
                             <field name="postcode" />
                             <field name="date_availability" string="Available From" />
                         </group>
@@ -49,6 +51,14 @@
                                 </group>
                             </group>
                         </page>
+                        <page string="Other Info">
+                            <group>
+                                <group>
+                                    <field name="salesperson_id" />
+                                    <field name="buyer_id" />
+                                </group>
+                            </group>
+                        </page>
                     </notebook>
                 </sheet>
             </form>
@@ -66,6 +76,7 @@
                 <field name="bedrooms" />
                 <field name="living_area" string="Living Area (sqm)" />
                 <field name="facades" />
+                <field name="property_type_id" />
                 <filter name="available" string="Available" domain="[('state','in',['new','offer_received'])]" />
                 <filter name="by_postcode" string="Postcode" context="{'group_by':'postcode'}" />
             </search>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -52,6 +52,9 @@
                                 </group>
                             </group>
                         </page>
+                        <page string="Offers">
+                            <field name="offer_ids" />
+                        </page>
                         <page string="Other Info">
                             <group>
                                 <group>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -34,6 +34,7 @@
                         </group>
                         <group>
                             <field name="expected_price" />
+                            <field name="best_price" />
                             <field name="selling_price" />
                         </group>
                     </group>
@@ -49,6 +50,7 @@
                                     <field name="garden" />
                                     <field name="garden_area" string="Garden Area (sqm)" />
                                     <field name="garden_orientation" />
+                                    <field name="total_area" />
                                 </group>
                             </group>
                         </page>


### PR DESCRIPTION
**Chapter 8**
- Relational fields `property_type_id`, `buyer_id` and `salesperson_id` are included to `estate.property` model.
- `estate.property.tag` model, its List view, Form view and menu are created including its relationship `Many2may` with the `estate.property` model.
-  In the same way, `estate.property.offer` model is created with a `One2many` relationship to `estate.property`. The action and menu are omitted, since the form and list view are part of the form view in the `estate.property` model. 
- [Reference link](https://www.odoo.com/documentation/16.0/developer/tutorials/getting_started/08_relations.html)

**Chapter 9**
- Computed fields `total_area` and `best_price` with its respective functions are added to `estate.property` model. Also, an `onchange` function is created to set default values to `garden_area` and `garden_orientation` when `garden` field changes.
- `date_deadline` and `validity` are added to `estate.property.offer` model to compute and inverse the range of days while the offer will be valid.
- [Reference link](https://www.odoo.com/documentation/16.0/developer/tutorials/getting_started/09_compute_onchange.html)