### PR TITLE
[ADD] estate: Add actions and constraints

### DIFF
--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -1,5 +1,6 @@
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
+from odoo.tools import float_compare
 
 
 class EstateProperty(models.Model):
@@ -73,6 +74,17 @@ class EstateProperty(models.Model):
         else:
             self.garden_area = 0
             self.garden_orientation = None
+
+    @api.constrains("expected_price", "selling_price")
+    def _check_selling_price(self):
+        for record in self.filtered(lambda element: element.selling_price > 0):
+            if float_compare(record.selling_price, record.expected_price * 0.9, 2) < 0:
+                raise ValidationError(
+                    _(
+                        "The selling price must be at least 90% of the expected price. "
+                        "You must reduce the expected price if you want to accept this offer."
+                    )
+                )
 
     def action_set_property_as_sold(self):
         self.ensure_one()

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -1,4 +1,5 @@
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class EstateProperty(models.Model):
@@ -39,6 +40,7 @@ class EstateProperty(models.Model):
         required=True,
         default="new",
         copy=False,
+        string="Status",
     )
     property_type_id = fields.Many2one("estate.property.type")
     buyer_id = fields.Many2one("res.partner", copy=False)
@@ -66,3 +68,19 @@ class EstateProperty(models.Model):
         else:
             self.garden_area = 0
             self.garden_orientation = None
+
+    def action_set_property_as_sold(self):
+        self.ensure_one()
+
+        if self.state == "canceled":
+            raise UserError(_("A canceled property can not be sold."))
+        self.state = "sold"
+        return True
+
+    def action_set_property_as_canceled(self):
+        self.ensure_one()
+
+        if self.state == "sold":
+            raise UserError(_("A sold property can not be canceled."))
+        self.state = "canceled"
+        return True

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -6,6 +6,7 @@ from odoo.tools import float_compare
 class EstateProperty(models.Model):
     _name = "estate.property"
     _description = "Estate property model"
+    _order = "id desc"
 
     name = fields.Char(required=True)
     description = fields.Text()

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -50,6 +50,11 @@ class EstateProperty(models.Model):
     total_area = fields.Integer(compute="_compute_total_area")
     best_price = fields.Float(compute="_compute_best_price")
 
+    _sql_constraints = [
+        ("check_expected_price", "CHECK(expected_price > 0)", "The expected price must be strictly positive."),
+        ("check_selling_price", "CHECK(selling_price >= 0)", "The selling price must be strictly positive."),
+    ]
+
     @api.depends("living_area", "garden_area")
     def _compute_total_area(self):
         for record in self:

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -5,6 +5,7 @@ from odoo.exceptions import UserError
 class PropertyOffer(models.Model):
     _name = "estate.property.offer"
     _description = "Offers for properties"
+    _order = "price desc"
 
     price = fields.Float()
     status = fields.Selection(

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -19,6 +19,10 @@ class PropertyOffer(models.Model):
     validity = fields.Integer(default=7, string="Validity (days)")
     date_deadline = fields.Date(compute="_compute_date_deadline", inverse="_inverse_validity", string="Deadline")
 
+    _sql_constraints = [
+        ("check_price", "CHECK(price > 0)", "The price must be strictly positive"),
+    ]
+
     def _inverse_validity(self):
         for record in self:
             end_date = fields.Date.to_date(record.create_date) if record.create_date else fields.Date.today()

--- a/estate/models/estate_property_tag.py
+++ b/estate/models/estate_property_tag.py
@@ -4,6 +4,7 @@ from odoo import fields, models
 class PropertyTag(models.Model):
     _name = "estate.property.tag"
     _description = "Tags for properties"
+    _order = "name"
 
     name = fields.Char(required=True)
 

--- a/estate/models/estate_property_tag.py
+++ b/estate/models/estate_property_tag.py
@@ -6,3 +6,5 @@ class PropertyTag(models.Model):
     _description = "Tags for properties"
 
     name = fields.Char(required=True)
+
+    _sql_constraints = [("name_unique", "UNIQUE(name)", "The name must be unique.")]

--- a/estate/models/estate_property_type.py
+++ b/estate/models/estate_property_type.py
@@ -4,8 +4,10 @@ from odoo import fields, models
 class PropertyType(models.Model):
     _name = "estate.property.type"
     _description = "Type of a property"
+    _order = "secuence, name"
 
     name = fields.Char()
     property_ids = fields.One2many("estate.property", "property_type_id")
+    secuence = fields.Integer(default=1)
 
     _sql_constraints = [("name_unique", "UNIQUE(name)", "The name must be unique.")]

--- a/estate/models/estate_property_type.py
+++ b/estate/models/estate_property_type.py
@@ -6,3 +6,5 @@ class PropertyType(models.Model):
     _description = "Type of a property"
 
     name = fields.Char()
+
+    _sql_constraints = [("name_unique", "UNIQUE(name)", "The name must be unique.")]

--- a/estate/models/estate_property_type.py
+++ b/estate/models/estate_property_type.py
@@ -6,5 +6,6 @@ class PropertyType(models.Model):
     _description = "Type of a property"
 
     name = fields.Char()
+    property_ids = fields.One2many("estate.property", "property_type_id")
 
     _sql_constraints = [("name_unique", "UNIQUE(name)", "The name must be unique.")]

--- a/estate/views/estate_property_offer_views.xml
+++ b/estate/views/estate_property_offer_views.xml
@@ -9,6 +9,8 @@
                 <field name="partner_id" />
                 <field name="validity" />
                 <field name="date_deadline" />
+                <button name="action_accept_offer" type="object" string="Accept" icon="fa-check" />
+                <button name="action_refuse_offer" type="object" string="Refuse" icon="fa-times" />
                 <field name="status" />
             </tree>
         </field>

--- a/estate/views/estate_property_type_views.xml
+++ b/estate/views/estate_property_type_views.xml
@@ -7,6 +7,17 @@
             <form string="Property Type">
                 <sheet>
                     <field name="name" style="font-size: 24pt;" />
+                    <notebook>
+                        <page string="Properties">
+                            <field name="property_ids">
+                                <tree create="false" delete="false" edit="false">
+                                    <field name="name" />
+                                    <field name="expected_price" />
+                                    <field name="state" />
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
                 </sheet>
             </form>
         </field>

--- a/estate/views/estate_property_type_views.xml
+++ b/estate/views/estate_property_type_views.xml
@@ -23,6 +23,17 @@
         </field>
     </record>
 
+    <record id="estate_property_type_view_tree" model="ir.ui.view">
+        <field name="name">estate.property.type.tree</field>
+        <field name="model">estate.property.type</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="secuence" widget="handle" />
+                <field name="name" />
+            </tree>
+        </field>
+    </record>
+
     <record id="estate_property_type_action" model="ir.actions.act_window">
         <field name="name">Property Types</field>
         <field name="res_model">estate.property.type</field>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -26,13 +26,17 @@
                 <header>
                     <button name="action_set_property_as_sold" type="object" string="Sold" />
                     <button name="action_set_property_as_canceled" type="object" string="Cancel" />
+                    <field
+                        name="state"
+                        widget="statusbar"
+                        statusbar_visible="new,offer_received,offer_accepted,sold"
+                    />
                 </header>
                 <sheet>
                     <group>
                         <field name="name" style="font-size:24pt;" />
                         <field name="tag_ids" widget="many2many_tags" />
                         <group>
-                            <field name="state" />
                             <field name="property_type_id" />
                             <field name="postcode" />
                             <field name="date_availability" string="Available From" />

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -23,11 +23,16 @@
         <field name="model">estate.property</field>
         <field name="arch" type="xml">
             <form string="Property">
+                <header>
+                    <button name="action_set_property_as_sold" type="object" string="Sold" />
+                    <button name="action_set_property_as_canceled" type="object" string="Cancel" />
+                </header>
                 <sheet>
                     <group>
                         <field name="name" style="font-size:24pt;" />
                         <field name="tag_ids" widget="many2many_tags" />
                         <group>
+                            <field name="state" />
                             <field name="property_type_id" />
                             <field name="postcode" />
                             <field name="date_availability" string="Available From" />


### PR DESCRIPTION
**Chapter 10**
- In order to sell or cancel a property, and accept or refuse a property offer, buttons and their respective action functions were created in `estate.property` and `estate.property.offer` models.
- [Reference link.](https://www.odoo.com/documentation/16.0/developer/tutorials/getting_started/10_actions.html)

**Chapter 11**
- SQL constraints were added in `estate.property`, `estate.property.offer`, `estate.property.tag` and `estate.property.type` to ensure the uniqueness of fields like `name` and that quantity fields be grater than 0 and.
- A Python function constrain were added to `estate.property` to ensure that the `selling_price` be at least 90% of the `expected_price`. 
- [Reference link](https://www.odoo.com/documentation/16.0/developer/tutorials/getting_started/11_constraints.html#)

**Chapter 12**
- A inline list view of properties is included in the `estate.property.type` form view to visualize the properties registered that corresponds to the current property type.
- Use `statusbar` widget to display the property `state`.  
- Set default order for each model using `_order` attr and implement manual order by `secuence` field in `estate.property.type` model.
- [Reference link](https://www.odoo.com/documentation/16.0/developer/tutorials/getting_started/12_sprinkles.html#inline-views)