### PR TITLE
[IMP] estate: UI improvement and validations

### DIFF
--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -7,9 +7,9 @@
     "data": [
         "security/ir.model.access.csv",
         "views/estate_property_views.xml",
+        "views/estate_property_offer_views.xml",
         "views/estate_property_type_views.xml",
         "views/estate_property_tag_views.xml",
-        "views/estate_property_offer_views.xml",
         "views/estate_menus.xml",
     ],
     "installable": True,

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -87,6 +87,11 @@ class EstateProperty(models.Model):
                     )
                 )
 
+    @api.ondelete(at_uninstall=False)
+    def _unlik_if_new_or_canceled(self):
+        if any(property.state not in ["new", "canceled"] for property in self):
+            raise UserError(_("Only new or canceled properties can be deleted."))
+
     def action_set_property_as_sold(self):
         self.ensure_one()
 

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -19,6 +19,7 @@ class PropertyOffer(models.Model):
     property_id = fields.Many2one("estate.property", required=True)
     validity = fields.Integer(default=7, string="Validity (days)")
     date_deadline = fields.Date(compute="_compute_date_deadline", inverse="_inverse_validity", string="Deadline")
+    property_type_id = fields.Many2one(related="property_id.property_type_id", store=True)
 
     _sql_constraints = [
         ("check_price", "CHECK(price > 0)", "The price must be strictly positive"),

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -36,6 +36,17 @@ class PropertyOffer(models.Model):
             start_date = record.create_date if record.create_date else fields.Date.today()
             record.date_deadline = fields.Date.add(start_date, days=record.validity)
 
+    @api.model
+    def create(self, vals):
+        property_instance = self.env["estate.property"].browse(vals["property_id"])
+        if property_instance.offer_ids:
+            price_max_offer = max(offer.price for offer in property_instance.offer_ids)
+            if vals["price"] < price_max_offer:
+                raise UserError(_("The offer must be higher than %d", price_max_offer))
+
+        property_instance.state = "offer_received"
+        return super().create(vals)
+
     def action_accept_offer(self):
         self.ensure_one()
 

--- a/estate/models/estate_property_tag.py
+++ b/estate/models/estate_property_tag.py
@@ -7,5 +7,6 @@ class PropertyTag(models.Model):
     _order = "name"
 
     name = fields.Char(required=True)
+    color = fields.Integer()
 
     _sql_constraints = [("name_unique", "UNIQUE(name)", "The name must be unique.")]

--- a/estate/models/estate_property_type.py
+++ b/estate/models/estate_property_type.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class PropertyType(models.Model):
@@ -9,5 +9,12 @@ class PropertyType(models.Model):
     name = fields.Char()
     property_ids = fields.One2many("estate.property", "property_type_id")
     secuence = fields.Integer(default=1)
+    offer_ids = fields.One2many("estate.property.offer", "property_type_id")
+    offer_count = fields.Integer(compute="_compute_offer_count")
 
     _sql_constraints = [("name_unique", "UNIQUE(name)", "The name must be unique.")]
+
+    @api.depends("offer_ids")
+    def _compute_offer_count(self):
+        for record in self:
+            record.offer_count = len(record.offer_ids)

--- a/estate/views/estate_property_offer_views.xml
+++ b/estate/views/estate_property_offer_views.xml
@@ -4,14 +4,26 @@
         <field name="name">estate.property.offer.tree</field>
         <field name="model">estate.property.offer</field>
         <field name="arch" type="xml">
-            <tree>
+            <tree editable="bottom" decoration-danger="status == 'refused'" decoration-success="status == 'accepted'">
                 <field name="price" />
                 <field name="partner_id" />
                 <field name="validity" />
                 <field name="date_deadline" />
-                <button name="action_accept_offer" type="object" string="Accept" icon="fa-check" />
-                <button name="action_refuse_offer" type="object" string="Refuse" icon="fa-times" />
-                <field name="status" />
+                <button
+                    name="action_accept_offer"
+                    type="object"
+                    string="Accept"
+                    icon="fa-check"
+                    attrs="{'invisible': [('status','!=', False)]}"
+                />
+                <button
+                    name="action_refuse_offer"
+                    type="object"
+                    string="Refuse"
+                    icon="fa-times"
+                    attrs="{'invisible': [('status','!=', False)]}"
+                />
+                <field name="status" invisible="1" />
             </tree>
         </field>
     </record>

--- a/estate/views/estate_property_offer_views.xml
+++ b/estate/views/estate_property_offer_views.xml
@@ -45,4 +45,11 @@
             </form>
         </field>
     </record>
+
+    <record id="estate_property_offer_action" model="ir.actions.act_window">
+        <field name="name">Property offer</field>
+        <field name="res_model">estate.property.offer</field>
+        <field name="view_mode">tree</field>
+        <field name="domain">[('property_type_id', '=', active_id)]</field>
+    </record>
 </odoo>

--- a/estate/views/estate_property_tag_views.xml
+++ b/estate/views/estate_property_tag_views.xml
@@ -1,5 +1,15 @@
 <?xml version='1.0' encoding='utf-8' ?>
 <odoo>
+    <record id="estate_property_tag_view_tree" model="ir.ui.view">
+        <field name="name">estate.property.tag.tree</field>
+        <field name="model">estate.property.tag</field>
+        <field name="arch" type="xml">
+            <tree editable="bottom">
+                <field name="name" />
+            </tree>
+        </field>
+    </record>
+
     <record id="estate_property_tag_action" model="ir.actions.act_window">
         <field name="name">Property Tags</field>
         <field name="res_model">estate.property.tag</field>

--- a/estate/views/estate_property_type_views.xml
+++ b/estate/views/estate_property_type_views.xml
@@ -6,6 +6,22 @@
         <field name="arch" type="xml">
             <form string="Property Type">
                 <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button
+                            class="oe_stat_button"
+                            name="%(estate_property_offer_action)d"
+                            type="action"
+                            icon="fa-money"
+                            string="Offers"
+                        >
+                            <div class="o_form_field o_stat_info">
+                                <span class="o_stat_text">
+                                    <field name="offer_count" />
+                                    <span> Offers</span>
+                                </span>
+                            </div>
+                        </button>
+                    </div>
                     <field name="name" style="font-size: 24pt;" />
                     <notebook>
                         <page string="Properties">

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -4,16 +4,21 @@
         <field name="name">estate.property.tree</field>
         <field name="model">estate.property</field>
         <field name="arch" type="xml">
-            <tree>
+            <tree
+                decoration-success="state in ('offer_received', 'offer_accepted')"
+                decoration-bf="state == 'offer_accepted'"
+                decoration-muted="state == 'sold'"
+            >
+                <field name="state" invisible="1" />
                 <field name="name" string="Title" />
                 <field name="property_type_id" />
-                <field name="tag_ids" widget="many2many_tags" />
+                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" />
                 <field name="postcode" />
                 <field name="bedrooms" />
                 <field name="living_area" string="Living Area (sqm)" />
                 <field name="expected_price" />
                 <field name="selling_price" />
-                <field name="date_availability" string="Available From" />
+                <field name="date_availability" string="Available From" optional="hide" />
             </tree>
         </field>
     </record>
@@ -24,8 +29,18 @@
         <field name="arch" type="xml">
             <form string="Property">
                 <header>
-                    <button name="action_set_property_as_sold" type="object" string="Sold" />
-                    <button name="action_set_property_as_canceled" type="object" string="Cancel" />
+                    <button
+                        name="action_set_property_as_sold"
+                        type="object"
+                        string="Sold"
+                        states="new,offer_received,offer_accepted"
+                    />
+                    <button
+                        name="action_set_property_as_canceled"
+                        type="object"
+                        string="Cancel"
+                        states="new,offer_received,offer_accepted"
+                    />
                     <field
                         name="state"
                         widget="statusbar"
@@ -35,10 +50,9 @@
                 <sheet>
                     <group>
                         <field name="name" style="font-size:24pt;" />
-                        <field name="tag_ids" widget="many2many_tags" />
+                        <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" />
                         <group>
-                            <field name="state" />
-                            <field name="property_type_id" />
+                            <field name="property_type_id" options="{'no_create': True}" />
                             <field name="postcode" />
                             <field name="date_availability" string="Available From" />
                         </group>
@@ -58,14 +72,21 @@
                                     <field name="facades" />
                                     <field name="garage" />
                                     <field name="garden" />
-                                    <field name="garden_area" string="Garden Area (sqm)" />
-                                    <field name="garden_orientation" />
+                                    <field
+                                        name="garden_area"
+                                        string="Garden Area (sqm)"
+                                        attrs="{'invisible': [('garden','=', False)]}"
+                                    />
+                                    <field name="garden_orientation" attrs="{'invisible': [('garden','=', False)]}" />
                                     <field name="total_area" />
                                 </group>
                             </group>
                         </page>
                         <page string="Offers">
-                            <field name="offer_ids" />
+                            <field
+                                name="offer_ids"
+                                attrs="{'readonly': [('state', 'in', ['offer_accepted', 'sold', 'canceled'])]}"
+                            />
                         </page>
                         <page string="Other Info">
                             <group>
@@ -90,7 +111,7 @@
                 <field name="postcode" />
                 <field name="expected_price" />
                 <field name="bedrooms" />
-                <field name="living_area" string="Living Area (sqm)" />
+                <field name="living_area" string="Living Area (sqm)" filter_domain="[('living_area', '>=', self)]" />
                 <field name="facades" />
                 <field name="property_type_id" />
                 <filter name="available" string="Available" domain="[('state','in',['new','offer_received'])]" />
@@ -103,5 +124,7 @@
         <field name="name">Estate Property</field>
         <field name="res_model">estate.property</field>
         <field name="view_mode">tree,form</field>
+        <field name="search_view_id" ref="estate_property_view_search" />
+        <field name="context">{'search_default_available': True}</field>
     </record>
 </odoo>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -37,6 +37,7 @@
                         <field name="name" style="font-size:24pt;" />
                         <field name="tag_ids" widget="many2many_tags" />
                         <group>
+                            <field name="state" />
                             <field name="property_type_id" />
                             <field name="postcode" />
                             <field name="date_availability" string="Available From" />


### PR DESCRIPTION
Chapter 12
- Implement color option to display `estate.property.tag` in property list view.
- Use `options` and `attrs` attributes to show or hide element, allow edit and change to readonly field.
- Implement context to set a default search value for `estate.property` list view.
- Create relation for offers and property types to implement stat button in `estate.property.type` list view.
- [Reference link](https://www.odoo.com/documentation/16.0/developer/tutorials/getting_started/12_sprinkles.html#attributes-and-options)

Chapter 13
- Implement `ondelete` function to avoid deleting properties that are not in state `new` or `canceled`.
- Implement `create` function to validate if an offer is grather than the max one already registered. Also sets the property state to `offer_receives`.
- [Reference lin](https://www.odoo.com/documentation/16.0/developer/tutorials/getting_started/13_inheritance.html#python-inheritance)