### PR TITLE
[ADD] estate_account: Inheritance and module interaction

### DIFF
--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -10,6 +10,7 @@
         "views/estate_property_offer_views.xml",
         "views/estate_property_type_views.xml",
         "views/estate_property_tag_views.xml",
+        "views/res_users_views.xml",
         "views/estate_menus.xml",
     ],
     "installable": True,

--- a/estate/models/__init__.py
+++ b/estate/models/__init__.py
@@ -2,3 +2,4 @@ from . import estate_property
 from . import estate_property_type
 from . import estate_property_tag
 from . import estate_property_offer
+from . import res_users

--- a/estate/models/res_users.py
+++ b/estate/models/res_users.py
@@ -1,0 +1,9 @@
+from odoo import fields, models
+
+
+class Users(models.Model):
+    _inherit = "res.users"
+
+    property_ids = fields.One2many(
+        "estate.property", "salesperson_id", domain=[("state", "not in", ["sold", "canceled"])]
+    )

--- a/estate/views/res_users_views.xml
+++ b/estate/views/res_users_views.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="res_users_view_form" model="ir.ui.view">
+        <field name="name">res.users.view.form.inherit.estate</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form" />
+        <field name="arch" type="xml">
+            <page name="preferences" position="after">
+                <page name="estate_properties" string="Real Estate Properties">
+                    <field name="property_ids" readonly="1" />
+                </page>
+            </page>
+        </field>
+    </record>
+</odoo>

--- a/estate_account/README.rst
+++ b/estate_account/README.rst
@@ -1,0 +1,3 @@
+## Estate Account
+
+Estate Account module to allow Real Estate module create invoices.

--- a/estate_account/__init__.py
+++ b/estate_account/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/estate_account/__manifest__.py
+++ b/estate_account/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    "name": "Estate Account",
+    "author": "Vauxoo",
+    "depends": [
+        "estate",
+        "account",
+    ],
+    "data": [],
+    "application": True,
+    "installable": True,
+    "license": "LGPL-3",
+}

--- a/estate_account/models/__init__.py
+++ b/estate_account/models/__init__.py
@@ -1,0 +1,1 @@
+from . import estate_property

--- a/estate_account/models/estate_property.py
+++ b/estate_account/models/estate_property.py
@@ -1,0 +1,39 @@
+from odoo import Command, models
+
+
+class EstateProperty(models.Model):
+    _inherit = "estate.property"
+
+    def action_set_property_as_sold(self):
+        self.ensure_one()
+
+        move_type = "out_invoice"
+        invoice_line_vals = self._create_invoice_lines()
+
+        invoice_vals = {
+            "partner_id": self.buyer_id.id,
+            "move_type": move_type,
+            "invoice_line_ids": invoice_line_vals,
+        }
+
+        self.env["account.move"].sudo().create([invoice_vals])
+        return super().action_set_property_as_sold()
+
+    def _create_invoice_lines(self):
+        invoice_line_vals = [
+            Command.create(
+                {
+                    "name": "Invoice",
+                    "quantity": 1,
+                    "price_unit": self.selling_price * 0.06,
+                }
+            ),
+            Command.create(
+                {
+                    "name": "Administrative fees",
+                    "quantity": 1,
+                    "price_unit": 100,
+                }
+            ),
+        ]
+        return invoice_line_vals


### PR DESCRIPTION
**Chapter 13**
- Extend `res.users` model to include `property_ids` field.
- Extend `base.view_users_form` to display the property list in new tab on the user view.
- [Reference link.](https://www.odoo.com/documentation/16.0/developer/tutorials/getting_started/13_inheritance.html#model-inheritance)

**Chapter 14**
- Create `estate_account` module with all its initial files (`__manifest__.py`, etc.).
- Extend `estate.property` model to override `action_set_property_as_sold` method and allow creating invoices for the property sales.
- [Reference link.](https://www.odoo.com/documentation/16.0/developer/tutorials/getting_started/14_other_module.html)