### PR TITLE
[ADD] estate: Add demo y data files

### DIFF
--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -18,6 +18,7 @@
     ],
     "demo": [
         "demo/estate_property.xml",
+        "demo/estate_property_offer.xml",
     ],
     "installable": True,
     "application": True,

--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -6,7 +6,7 @@
         "base",
     ],
     "data": [
-        "security/estate_security.xml",
+        "data/estate.property.type.csv",
         "security/ir.model.access.csv",
         "security/estate_security.xml",
         "views/estate_property_views.xml",
@@ -15,6 +15,9 @@
         "views/estate_property_tag_views.xml",
         "views/res_users_views.xml",
         "views/estate_menus.xml",
+    ],
+    "demo": [
+        "demo/estate_property.xml",
     ],
     "installable": True,
     "application": True,

--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -8,6 +8,7 @@
     "data": [
         "security/estate_security.xml",
         "security/ir.model.access.csv",
+        "security/estate_security.xml",
         "views/estate_property_views.xml",
         "views/estate_property_offer_views.xml",
         "views/estate_property_type_views.xml",

--- a/estate/data/estate.property.type.csv
+++ b/estate/data/estate.property.type.csv
@@ -1,0 +1,5 @@
+id,name
+type_residential,Residential
+type_commercial,Commercial
+type_industrial,Industrial
+type_land,Land

--- a/estate/demo/estate_property.xml
+++ b/estate/demo/estate_property.xml
@@ -3,6 +3,7 @@
     <record id="estate_property_big_villa_demo" model="estate.property">
         <field name="name">Big Villa</field>
         <field name="state">new</field>
+        <field name="property_type_id" ref="type_residential" />
         <field name="description">A nice and big villa</field>
         <field name="postcode">12345</field>
         <field name="date_availability">2020-02-02</field>
@@ -19,6 +20,7 @@
     <record id="estate_property_trailer_home_demo" model="estate.property">
         <field name="name">Trailer Home</field>
         <field name="state">canceled</field>
+        <field name="property_type_id" ref="type_residential" />
         <field name="description">Home in a trailer park</field>
         <field name="postcode">54321</field>
         <field name="date_availability">1970-01-01</field>
@@ -28,5 +30,34 @@
         <field name="living_area">10</field>
         <field name="facades">4</field>
         <field name="garage">False</field>
+    </record>
+
+    <record id="estate_property_pretty_home_demo" model="estate.property">
+        <field name="name">Pretty Home</field>
+        <field name="state">new</field>
+        <field name="property_type_id" ref="type_residential" />
+        <field name="description">Pretty home of your dreams</field>
+        <field name="postcode">54321</field>
+        <field name="date_availability">2023-01-01</field>
+        <field name="expected_price">300000</field>
+        <field name="bedrooms">1</field>
+        <field name="living_area">100</field>
+        <field name="facades">1</field>
+        <field name="garage">False</field>
+        <field
+            name="offer_ids"
+            eval="[
+                Command.create({
+                    'price': 300000,
+                    'partner_id': ref('base.res_partner_12'),
+                    'validity': 20,
+                }),
+                Command.create({
+                    'price': 300002,
+                    'partner_id': ref('base.res_partner_2'),
+                    'validity': 25,
+                }),
+            ]"
+        />
     </record>
 </odoo>

--- a/estate/demo/estate_property.xml
+++ b/estate/demo/estate_property.xml
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="estate_property_big_villa_demo" model="estate.property">
+        <field name="name">Big Villa</field>
+        <field name="state">new</field>
+        <field name="description">A nice and big villa</field>
+        <field name="postcode">12345</field>
+        <field name="date_availability">2020-02-02</field>
+        <field name="expected_price">1600000</field>
+        <field name="bedrooms">6</field>
+        <field name="living_area">100</field>
+        <field name="facades">4</field>
+        <field name="garage">True</field>
+        <field name="garden">True</field>
+        <field name="garden_area">100000</field>
+        <field name="garden_orientation">south</field>
+    </record>
+
+    <record id="estate_property_trailer_home_demo" model="estate.property">
+        <field name="name">Trailer Home</field>
+        <field name="state">canceled</field>
+        <field name="description">Home in a trailer park</field>
+        <field name="postcode">54321</field>
+        <field name="date_availability">1970-01-01</field>
+        <field name="expected_price">100000</field>
+        <field name="selling_price">120000</field>
+        <field name="bedrooms">1</field>
+        <field name="living_area">10</field>
+        <field name="facades">4</field>
+        <field name="garage">False</field>
+    </record>
+</odoo>

--- a/estate/demo/estate_property_offer.xml
+++ b/estate/demo/estate_property_offer.xml
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="estate_property_offer_1_demo" model="estate.property.offer">
+        <field name="partner_id" ref="base.res_partner_12" />
+        <field name="property_id" ref="estate_property_big_villa_demo" />
+        <field name="price">10000</field>
+        <field name="validity">14</field>
+        <field name="date_deadline" eval="datetime.now() + timedelta(days=14)" />
+    </record>
+
+    <record id="estate_property_offer_2_demo" model="estate.property.offer">
+        <field name="partner_id" ref="base.res_partner_12" />
+        <field name="property_id" ref="estate_property_big_villa_demo" />
+        <field name="price">1500000</field>
+        <field name="validity">14</field>
+        <field name="date_deadline" eval="datetime.now() + timedelta(days=14)" />
+    </record>
+
+    <record id="estate_property_offer_3_demo" model="estate.property.offer">
+        <field name="partner_id" ref="base.res_partner_2" />
+        <field name="property_id" ref="estate_property_big_villa_demo" />
+        <field name="price">1500001</field>
+        <field name="validity">14</field>
+        <field name="date_deadline" eval="datetime.now() + timedelta(days=14)" />
+    </record>
+
+    <function model="estate.property.offer" name="action_accept_offer" eval="[ref('estate_property_offer_3_demo')]" />
+    <function model="estate.property.offer" name="action_refuse_offer" eval="[ref('estate_property_offer_1_demo')]" />
+    <function model="estate.property.offer" name="action_refuse_offer" eval="[ref('estate_property_offer_2_demo')]" />
+</odoo>

--- a/estate_account/models/estate_property.py
+++ b/estate_account/models/estate_property.py
@@ -18,8 +18,6 @@ class EstateProperty(models.Model):
             "invoice_line_ids": invoice_line_vals,
         }
 
-        # self.env["account.move"].check_access_rights("write")
-        # print(" reached ".center(100, '='))
         self.env["account.move"].sudo().create([invoice_vals])
 
         return super().action_set_property_as_sold()


### PR DESCRIPTION
**Define module data**
- Create `estate.property.type.csv` to load initial property type data.
- Create `estate.property` demo data.
- Create `estate.property.offer` demo data that includes relationships, and functions to accept or refuse the offers.
- Create `estate.property` demo data with inline related offers.
- [Reference link](https://www.odoo.com/documentation/16.0/es/developer/tutorials/define_module_data.html#)