### PR TITLE
[ADD] estate: Create reports and translate module

### DIFF
--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -7,8 +7,8 @@
     ],
     "data": [
         "data/estate.property.type.csv",
-        "security/ir.model.access.csv",
         "security/estate_security.xml",
+        "security/ir.model.access.csv",
         "views/estate_property_views.xml",
         "views/estate_property_offer_views.xml",
         "views/estate_property_type_views.xml",

--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -15,6 +15,8 @@
         "views/estate_property_tag_views.xml",
         "views/res_users_views.xml",
         "views/estate_menus.xml",
+        "report/estate_property_templates.xml",
+        "report/estate_property_reports.xml",
     ],
     "demo": [
         "demo/estate_property.xml",

--- a/estate/i18n/es_ES.po
+++ b/estate/i18n/es_ES.po
@@ -1,0 +1,614 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* estate
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-07 22:29+0000\n"
+"PO-Revision-Date: 2023-07-07 22:29+0000\n"
+"Last-Translator: Gerardo Jiménez Argüelles\n"
+"Language-Team: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+
+#. module: estate
+#: model:ir.actions.report,print_report_name:estate.estate_property_offers_report_action
+msgid "'%s-offers' % object.name"
+msgstr "'%s-ofertas' % object.name"
+
+#. module: estate
+#: model:ir.actions.report,print_report_name:estate.estate_property_offers_salesman_report_action
+msgid "'%s-property-offers' % object.name"
+msgstr "'%s-ofertas-de-propiedades' % object.name"
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.property_offers_template
+msgid "<b>Expected price: </b>"
+msgstr "<b>Precio esperado: </b>"
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.property_offers_salesman_report
+#: model_terms:ir.ui.view,arch_db:estate.property_offers_template
+msgid "<b>Salesman: </b>"
+msgstr "<b>Vendedor: </b>"
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.property_offers_template
+msgid "<b>Status: </b>"
+msgstr "<b>Estatus: </b>"
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_type_view_form
+msgid "<span> Offers</span>"
+msgstr "<span> Ofertas</span>"
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_view_kanban
+msgid "<span>Best price: </span>"
+msgstr "<span>Mejor oferta: </span>"
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_view_kanban
+msgid "<span>Expected price: </span>"
+msgstr "<span>Precio esperado: </span>"
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_view_kanban
+msgid "<span>Selling price: </span>"
+msgstr "<span>Precio de venta: </span>"
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.property_offers_template
+msgid "<strong>No offers have been made yet.</strong>"
+msgstr "<strong>No se le han hecho ofertas todavía.</strong>"
+
+#. module: estate
+#. odoo-python
+#: code:addons/estate/models/estate_property.py:0
+#, python-format
+msgid "A canceled property can not be sold."
+msgstr "No se puede vender una propiedad que ha sido cancelada."
+
+#. module: estate
+#. odoo-python
+#: code:addons/estate/models/estate_property.py:0
+#, python-format
+msgid "A sold property can not be canceled."
+msgstr "No se puede cancelar una propiedad que ha sido vendida."
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_offer_view_tree
+msgid "Accept"
+msgstr "Aceptar"
+
+#. module: estate
+#: model:ir.model.fields.selection,name:estate.selection__estate_property_offer__status__accepted
+msgid "Accepted"
+msgstr "Aceptada"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__active
+msgid "Active"
+msgstr "Activa"
+
+#. module: estate
+#: model:ir.ui.menu,name:estate.advertisements_menu
+msgid "Advertisements"
+msgstr "Anuncios"
+
+#. module: estate
+#: model:res.groups,name:estate.estate_group_user
+msgid "Agent"
+msgstr "Agente"
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_view_search
+msgid "Available"
+msgstr "Disponible"
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_view_form
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_view_tree
+msgid "Available From"
+msgstr "Disponible desde"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__bedrooms
+msgid "Bedrooms"
+msgstr "Dormitorios"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__best_price
+msgid "Best Price"
+msgstr "Mejor oferta"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__buyer_id
+msgid "Buyer"
+msgstr "Comprador"
+
+#. module: estate
+#: model:res.groups,comment:estate.estate_group_manager
+msgid ""
+"Can configure the system as well as oversee every property in the pipeline."
+msgstr ""
+"Puede configurar el sistema, así como supervisar el proceso de cada "
+"propiedad."
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_view_form
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: estate
+#: model:ir.model.fields.selection,name:estate.selection__estate_property__state__canceled
+msgid "Canceled"
+msgstr "Cancelada"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property_tag__color
+msgid "Color"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__company_id
+msgid "Company"
+msgstr "Empresa"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__create_uid
+#: model:ir.model.fields,field_description:estate.field_estate_property_offer__create_uid
+#: model:ir.model.fields,field_description:estate.field_estate_property_tag__create_uid
+#: model:ir.model.fields,field_description:estate.field_estate_property_type__create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__create_date
+#: model:ir.model.fields,field_description:estate.field_estate_property_offer__create_date
+#: model:ir.model.fields,field_description:estate.field_estate_property_tag__create_date
+#: model:ir.model.fields,field_description:estate.field_estate_property_type__create_date
+msgid "Created on"
+msgstr "Creado el"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__date_availability
+msgid "Date Availability"
+msgstr "Fecha de disponibilidad"
+
+#. module: estate
+#: model:ir.model.fields,help:estate.field_estate_property__date_availability
+msgid "Date from when it will be available."
+msgstr "Fecha en la que estará disponible."
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property_offer__date_deadline
+#: model_terms:ir.ui.view,arch_db:estate.property_offers_template
+msgid "Deadline"
+msgstr "Fecha límite"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__description
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_view_form
+msgid "Description"
+msgstr "Descripción"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__display_name
+#: model:ir.model.fields,field_description:estate.field_estate_property_offer__display_name
+#: model:ir.model.fields,field_description:estate.field_estate_property_tag__display_name
+#: model:ir.model.fields,field_description:estate.field_estate_property_type__display_name
+msgid "Display Name"
+msgstr "Nombre a mostrar"
+
+#. module: estate
+#: model:ir.model.fields.selection,name:estate.selection__estate_property__garden_orientation__east
+msgid "East"
+msgstr "Este"
+
+#. module: estate
+#: model:ir.actions.act_window,name:estate.estate_property_action
+msgid "Estate Property"
+msgstr "Bienes raíces"
+
+#. module: estate
+#: model:ir.model,name:estate.model_estate_property
+msgid "Estate property model"
+msgstr "Modelo de bienes raíces"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__expected_price
+msgid "Expected Price"
+msgstr "Precio esperado"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__facades
+msgid "Facades"
+msgstr "Fachadas"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__garage
+msgid "Garage"
+msgstr "Cochera"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__garden
+msgid "Garden"
+msgstr "Jardín"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__garden_area
+msgid "Garden Area"
+msgstr "Área del jardín"
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_view_form
+msgid "Garden Area (sqm)"
+msgstr "Área del jardín (m2)"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__garden_orientation
+msgid "Garden Orientation"
+msgstr "Ubicación del jardín"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__id
+#: model:ir.model.fields,field_description:estate.field_estate_property_offer__id
+#: model:ir.model.fields,field_description:estate.field_estate_property_tag__id
+#: model:ir.model.fields,field_description:estate.field_estate_property_type__id
+msgid "ID"
+msgstr ""
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property____last_update
+#: model:ir.model.fields,field_description:estate.field_estate_property_offer____last_update
+#: model:ir.model.fields,field_description:estate.field_estate_property_tag____last_update
+#: model:ir.model.fields,field_description:estate.field_estate_property_type____last_update
+msgid "Last Modified on"
+msgstr "Última modificación el"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__write_uid
+#: model:ir.model.fields,field_description:estate.field_estate_property_offer__write_uid
+#: model:ir.model.fields,field_description:estate.field_estate_property_tag__write_uid
+#: model:ir.model.fields,field_description:estate.field_estate_property_type__write_uid
+msgid "Last Updated by"
+msgstr "Última modificación por"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__write_date
+#: model:ir.model.fields,field_description:estate.field_estate_property_offer__write_date
+#: model:ir.model.fields,field_description:estate.field_estate_property_tag__write_date
+#: model:ir.model.fields,field_description:estate.field_estate_property_type__write_date
+msgid "Last Updated on"
+msgstr "Última actualización el"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__living_area
+msgid "Living Area"
+msgstr "Superficie habitable"
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_view_form
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_view_search
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_view_tree
+msgid "Living Area (sqm)"
+msgstr "Superficie habitable (m2)"
+
+#. module: estate
+#: model:res.groups,comment:estate.estate_group_user
+msgid ""
+"Manage the properties under their care and properties which are not "
+"specifically under the care of any agent."
+msgstr ""
+"Administra las propiedades bajo su cargo y aquellas que no están a cargo de "
+"ningún agente."
+
+#. module: estate
+#: model:res.groups,name:estate.estate_group_manager
+msgid "Manager"
+msgstr "Administrador"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__name
+#: model:ir.model.fields,field_description:estate.field_estate_property_tag__name
+#: model:ir.model.fields,field_description:estate.field_estate_property_type__name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: estate
+#: model:ir.model.fields.selection,name:estate.selection__estate_property__state__new
+msgid "New"
+msgstr "Nueva"
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.property_offers_template
+msgid "No assigned yet."
+msgstr "No asignada todavía."
+
+#. module: estate
+#: model:ir.model.fields.selection,name:estate.selection__estate_property__garden_orientation__north
+msgid "North"
+msgstr "Norte"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__offer_ids
+#: model:ir.model.fields,field_description:estate.field_estate_property_type__offer_ids
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_offer_view_form
+msgid "Offer"
+msgstr "Oferta"
+
+#. module: estate
+#: model:ir.model.fields.selection,name:estate.selection__estate_property__state__offer_accepted
+msgid "Offer Accepted"
+msgstr "Oferta aceptada"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property_type__offer_count
+msgid "Offer Count"
+msgstr "Cantidad de ofertas"
+
+#. module: estate
+#: model:ir.model.fields.selection,name:estate.selection__estate_property__state__offer_received
+msgid "Offer Received"
+msgstr "Oferta recibida"
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_type_view_form
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_view_form
+msgid "Offers"
+msgstr "Ofertas"
+
+#. module: estate
+#: model:ir.model,name:estate.model_estate_property_offer
+msgid "Offers for properties"
+msgstr "Ofertas para las propiedades"
+
+#. module: estate
+#. odoo-python
+#: code:addons/estate/models/estate_property.py:0
+#, python-format
+msgid "Only new or canceled properties can be deleted."
+msgstr "Solo propiedades nuevas o canceladas pueden ser eliminadas."
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_view_form
+msgid "Other Info"
+msgstr "Otra información"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property_offer__partner_id
+#: model_terms:ir.ui.view,arch_db:estate.property_offers_template
+msgid "Partner"
+msgstr "Colaborador"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__postcode
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_view_search
+msgid "Postcode"
+msgstr "Código postal"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property_offer__price
+#: model_terms:ir.ui.view,arch_db:estate.property_offers_template
+msgid "Price"
+msgstr "Precio"
+
+#. module: estate
+#: model:ir.model.fields,help:estate.field_estate_property__expected_price
+msgid "Price at which you wish to sell the property."
+msgstr "Precio al que se desea vender la propiedad."
+
+#. module: estate
+#: model:ir.ui.menu,name:estate.estate_property_menu
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_type_view_form
+msgid "Properties"
+msgstr "Propiedades"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property_offer__property_id
+#: model:ir.model.fields,field_description:estate.field_estate_property_type__property_ids
+#: model:ir.model.fields,field_description:estate.field_res_users__property_ids
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_view_form
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_view_search
+msgid "Property"
+msgstr "Propiedad"
+
+#. module: estate
+#: model:ir.actions.act_window,name:estate.estate_property_tag_action
+#: model:ir.ui.menu,name:estate.estate_property_tag_menu
+msgid "Property Tags"
+msgstr "Etiquetas para propiedades"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__property_type_id
+#: model:ir.model.fields,field_description:estate.field_estate_property_offer__property_type_id
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_type_view_form
+msgid "Property Type"
+msgstr "Tipo de propiedad"
+
+#. module: estate
+#: model:ir.actions.act_window,name:estate.estate_property_type_action
+#: model:ir.ui.menu,name:estate.estate_property_type_menu
+msgid "Property Types"
+msgstr "Tipos de propiedades"
+
+#. module: estate
+#: model:ir.actions.act_window,name:estate.estate_property_offer_action
+msgid "Property offer"
+msgstr "Oferta de propiedad"
+
+#. module: estate
+#: model:ir.actions.report,name:estate.estate_property_offers_report_action
+#: model:ir.actions.report,name:estate.estate_property_offers_salesman_report_action
+msgid "Property offers"
+msgstr "Ofertas de propiedades"
+
+#. module: estate
+#: model:ir.ui.menu,name:estate.estate_menu_root
+msgid "Real Estate"
+msgstr "Bienes Raíces"
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.res_users_view_form
+msgid "Real Estate Properties"
+msgstr "Propiedades de bienes raíces"
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_offer_view_tree
+msgid "Refuse"
+msgstr "Rechazar"
+
+#. module: estate
+#: model:ir.model.fields.selection,name:estate.selection__estate_property_offer__status__refused
+msgid "Refused"
+msgstr "Rechazada"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__salesperson_id
+msgid "Salesman"
+msgstr "Vendedor"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__selling_price
+msgid "Selling Price"
+msgstr "Precio de venta"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property_type__sequence
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: estate
+#: model:ir.ui.menu,name:estate.settings_menu
+msgid "Settings"
+msgstr "Configuraciones"
+
+#. module: estate
+#: model:ir.model.fields.selection,name:estate.selection__estate_property__state__sold
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_view_form
+msgid "Sold"
+msgstr "Vendida"
+
+#. module: estate
+#: model:ir.model.fields.selection,name:estate.selection__estate_property__garden_orientation__south
+msgid "South"
+msgstr "Sur"
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.property_offers_template
+msgid "State"
+msgstr "Estado"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__state
+#: model:ir.model.fields,field_description:estate.field_estate_property_offer__status
+msgid "Status"
+msgstr "Estado"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__tag_ids
+msgid "Tag"
+msgstr "Etiqueta"
+
+#. module: estate
+#: model:ir.model,name:estate.model_estate_property_tag
+msgid "Tags for properties"
+msgstr "Etiquetas para propiedades"
+
+#. module: estate
+#: model:ir.model.constraint,message:estate.constraint_estate_property_check_expected_price
+msgid "The expected price must be strictly positive."
+msgstr "El precio esperado debe ser estrictamente positivo."
+
+#. module: estate
+#: model:ir.model.constraint,message:estate.constraint_estate_property_tag_name_unique
+#: model:ir.model.constraint,message:estate.constraint_estate_property_type_name_unique
+msgid "The name must be unique."
+msgstr "El nombre debe ser único."
+
+#. module: estate
+#. odoo-python
+#: code:addons/estate/models/estate_property_offer.py:0
+#, python-format
+msgid "The offer must be higher than %d"
+msgstr "La oferta debe ser más alta que %d"
+
+#. module: estate
+#: model:ir.model.constraint,message:estate.constraint_estate_property_offer_check_price
+msgid "The price must be strictly positive"
+msgstr "El precio debe ser estrictamente positivo"
+
+#. module: estate
+#. odoo-python
+#: code:addons/estate/models/estate_property_offer.py:0
+#, python-format
+msgid "The property is already sold."
+msgstr "La propiedad ya fue vendida."
+
+#. module: estate
+#. odoo-python
+#: code:addons/estate/models/estate_property.py:0
+#, python-format
+msgid ""
+"The selling price must be at least 90% of the expected price. You must "
+"reduce the expected price if you want to accept this offer."
+msgstr ""
+"El precio de venta debe ser al menos el 90% del precio esperado. Debes de "
+"reducir el precio esperado si deseas aceptar esta oferta."
+
+#. module: estate
+#: model:ir.model.constraint,message:estate.constraint_estate_property_check_selling_price
+msgid "The selling price must be strictly positive."
+msgstr "El precio de venta debe ser estrictamente positivo."
+
+#. module: estate
+#. odoo-python
+#: code:addons/estate/models/estate_property_offer.py:0
+#, python-format
+msgid "There is an offer accepted already for this property."
+msgstr "Ya hay una oferta aceptada para esta propiedad."
+
+#. module: estate
+#. odoo-python
+#: code:addons/estate/models/estate_property.py:0
+#, python-format
+msgid "There is no offer accepted."
+msgstr "No hay oferta aceptada."
+
+#. module: estate
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_view_search
+#: model_terms:ir.ui.view,arch_db:estate.estate_property_view_tree
+msgid "Title"
+msgstr "Título"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property__total_area
+msgid "Total Area"
+msgstr "Área total"
+
+#. module: estate
+#: model:ir.model,name:estate.model_estate_property_type
+msgid "Type of a property"
+msgstr "Tipo de una propiedad"
+
+#. module: estate
+#: model:ir.model,name:estate.model_res_users
+msgid "User"
+msgstr "Usuario"
+
+#. module: estate
+#: model:ir.model.fields,field_description:estate.field_estate_property_offer__validity
+#: model_terms:ir.ui.view,arch_db:estate.property_offers_template
+msgid "Validity (days)"
+msgstr "Validez (días)"
+
+#. module: estate
+#: model:ir.model.fields.selection,name:estate.selection__estate_property__garden_orientation__west
+msgid "West"
+msgstr "Oeste"

--- a/estate/models/estate_property_type.py
+++ b/estate/models/estate_property_type.py
@@ -4,11 +4,11 @@ from odoo import api, fields, models
 class PropertyType(models.Model):
     _name = "estate.property.type"
     _description = "Type of a property"
-    _order = "secuence, name"
+    _order = "sequence, name"
 
     name = fields.Char()
     property_ids = fields.One2many("estate.property", "property_type_id")
-    secuence = fields.Integer(default=1)
+    sequence = fields.Integer(default=1)
     offer_ids = fields.One2many("estate.property.offer", "property_type_id")
     offer_count = fields.Integer(compute="_compute_offer_count")
 

--- a/estate/report/estate_property_reports.xml
+++ b/estate/report/estate_property_reports.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="estate_property_offers_report_action" model="ir.actions.report">
+        <field name="name">Property offers</field>
+        <field name="model">estate.property</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">estate.property_offers_report</field>
+        <field name="report_file">property_offers_report</field>
+        <field name="print_report_name">'%s-offers' % object.name</field>
+        <field name="binding_model_id" ref="model_estate_property" />
+    </record>
+
+    <record id="estate_property_offers_salesman_report_action" model="ir.actions.report">
+        <field name="name">Property offers</field>
+        <field name="model">res.users</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">estate.property_offers_salesman_report</field>
+        <field name="report_file">property_offers_salesman_report</field>
+        <field name="print_report_name">'%s-property-offers' % object.name</field>
+        <field name="binding_model_id" ref="model_res_users" />
+    </record>
+</odoo>

--- a/estate/report/estate_property_templates.xml
+++ b/estate/report/estate_property_templates.xml
@@ -1,0 +1,90 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <template id="property_offers_template">
+        <h2>
+            <span t-field="property.name" />
+        </h2>
+        <div>
+            <b>Salesman: </b>
+            <span t-if="property.salesperson_id" t-field="property.salesperson_id" />
+            <span t-else="">No assigned yet.</span>
+        </div>
+        <div>
+            <b>Expected price: </b>
+            <span t-field="property.expected_price" />
+        </div>
+        <div>
+            <b>Status: </b>
+            <span t-field="property.state" />
+        </div>
+        <t t-if="property.offer_ids">
+            <t t-set="offers" t-value="property.mapped('offer_ids')" />
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Price</th>
+                        <th>Partner</th>
+                        <th>Validity (days)</th>
+                        <th>Deadline</th>
+                        <th>State</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr t-foreach="offers" t-as="offer">
+                        <td>
+                            <span t-field="offer.price" />
+                        </td>
+                        <td>
+                            <span t-field="offer.partner_id" />
+                        </td>
+                        <td>
+                            <span t-field="offer.validity" />
+                        </td>
+                        <td>
+                            <span t-field="offer.date_deadline" />
+                        </td>
+                        <td>
+                            <span t-field="offer.status" />
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </t>
+        <t t-else="">
+            <div>
+                <p><strong>No offers have been made yet.</strong></p>
+            </div>
+        </t>
+    </template>
+
+    <template id="property_offers_report">
+        <t t-foreach="docs" t-as="property">
+            <t t-call="web.html_container">
+                <t t-call="web.external_layout">
+                    <div class="page">
+                        <t t-call="estate.property_offers_template" />
+                    </div>
+                 </t>
+            </t>
+        </t>
+    </template>
+
+    <template id="property_offers_salesman_report">
+        <t t-foreach="docs" t-as="user">
+            <t t-call="web.html_container">
+                <t t-call="web.external_layout">
+                    <div class="page">
+                        <h1>
+                            <b>Salesman: </b>
+                            <span t-field="user.name" />
+                        </h1>
+                        <t t-set="properties" t-value="user.mapped('property_ids')" />
+                        <t t-foreach="properties" t-as="property">
+                            <t t-call="estate.property_offers_template" />
+                        </t>
+                    </div>
+                </t>
+            </t>
+        </t>
+    </template>
+</odoo>

--- a/estate/views/estate_property_type_views.xml
+++ b/estate/views/estate_property_type_views.xml
@@ -44,7 +44,7 @@
         <field name="model">estate.property.type</field>
         <field name="arch" type="xml">
             <tree>
-                <field name="secuence" widget="handle" />
+                <field name="sequence" widget="handle" />
                 <field name="name" />
             </tree>
         </field>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -141,7 +141,7 @@
         <field name="name">estate.property.search</field>
         <field name="model">estate.property</field>
         <field name="arch" type="xml">
-            <search string="Propery">
+            <search string="Property">
                 <field name="name" string="Title" />
                 <field name="postcode" />
                 <field name="expected_price" />

--- a/estate_account/__manifest__.py
+++ b/estate_account/__manifest__.py
@@ -5,7 +5,9 @@
         "estate",
         "account",
     ],
-    "data": [],
+    "data": [
+        "report/estate_property_templates.xml",
+    ],
     "application": True,
     "installable": True,
     "license": "LGPL-3",

--- a/estate_account/report/estate_property_templates.xml
+++ b/estate_account/report/estate_property_templates.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <template id="property_offers_invoice_template" inherit_id="estate.property_offers_template">
+        <xpath expr="//div[3]" position="after">
+            <div t-if="property.state == 'sold'">
+                <span><b>Invoice has been created.</b></span>
+            </div>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
**Build PDF reports**
- Create action and template to create `estate.property` with the basic property info and the offers made for it.
- Create action and template to create a report of all the properties and offers that a salesman owns.
- [Reference link](https://www.odoo.com/documentation/16.0/es/developer/tutorials/pdf_reports.html#)

**Translating modules**
- Create Spanish translate file of `estate_property` module.